### PR TITLE
Don't use root navigator for theme dialog

### DIFF
--- a/lib/src/widgets/widget.dart
+++ b/lib/src/widgets/widget.dart
@@ -334,6 +334,7 @@ class _DashbookState extends State<Dashbook> {
                                     onClick: () {
                                       showDialog<void>(
                                         context: context,
+                                        useRootNavigator: false,
                                         builder: (_) => AlertDialog(
                                           title: const Text('Theme chooser'),
                                           content: DropdownButton<ThemeData>(


### PR DESCRIPTION
This is a fix for https://github.com/bluefireteam/dashbook/issues/86

Currently the dialog uses the root navigator. In my example I wrapped the dashbook in a different materialapp, creating an extra navigator. The pop() in the dialog didn't remove the dialog, but the dashbook itself.