### PR TITLE
Don't only show wide logic on web

### DIFF
--- a/lib/src/device_size_extension.dart
+++ b/lib/src/device_size_extension.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+extension DeviceSizeExtension on BuildContext {
+  /// Is extra small is the group of device
+  SizeCategory get sizeCategory {
+    final width = MediaQuery.of(this).size.width;
+    if (width > _Breakpoint.large) return SizeCategory.desktop;
+    if (width > _Breakpoint.medium) return SizeCategory.laptop;
+    if (width > _Breakpoint.small) return SizeCategory.tablet;
+    return SizeCategory.phone;
+  }
+
+  bool get isNotPhoneSize => !isPhoneSize;
+  bool get isPhoneSize => sizeCategory == SizeCategory.phone;
+  bool get isTabletSize => sizeCategory == SizeCategory.tablet;
+  bool get isLaptopSize => sizeCategory == SizeCategory.laptop;
+  bool get isDesktopSize => sizeCategory == SizeCategory.desktop;
+}
+
+enum SizeCategory {
+  phone,
+  tablet,
+  laptop,
+  desktop,
+}
+
+/// These breakpoints are matched to those defined by the [material docs](https://material.io/design/layout/understanding-layout.html)
+/// The number represents the point it starts, so a device between 600 and 1240px wide is considered small.
+class _Breakpoint {
+  static const small = 600;
+  static const medium = 1240;
+  static const large = 1440;
+}

--- a/lib/src/device_size_extension.dart
+++ b/lib/src/device_size_extension.dart
@@ -25,7 +25,8 @@ enum SizeCategory {
 }
 
 /// These breakpoints are matched to those defined by the [material docs](https://material.io/design/layout/understanding-layout.html)
-/// The number represents the point it starts, so a device between 600 and 1240px wide is considered small.
+/// The number represents the point it starts, so a device between 600 and
+/// 1240px wide is considered small.
 class _Breakpoint {
   static const small = 600;
   static const medium = 1240;

--- a/lib/src/widgets/preview_container.dart
+++ b/lib/src/widgets/preview_container.dart
@@ -1,3 +1,4 @@
+import 'package:dashbook/src/device_size_extension.dart';
 import 'package:dashbook/src/widgets/device_preview.dart';
 import 'package:dashbook/src/widgets/helpers.dart';
 import 'package:device_frame/device_frame.dart';
@@ -55,7 +56,9 @@ class PreviewContainer extends StatelessWidget {
       top: 0,
       bottom: 0,
       left: 0,
-      right: (kIsWeb && isPropertiesOpen) ? sideBarSizeProperties(context) : 0,
+      right: (context.isNotPhoneSize && isPropertiesOpen)
+          ? sideBarSizeProperties(context)
+          : 0,
       child: info == null
           ? preview
           : Stack(

--- a/lib/src/widgets/preview_container.dart
+++ b/lib/src/widgets/preview_container.dart
@@ -2,7 +2,6 @@ import 'package:dashbook/src/device_size_extension.dart';
 import 'package:dashbook/src/widgets/device_preview.dart';
 import 'package:dashbook/src/widgets/helpers.dart';
 import 'package:device_frame/device_frame.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class PreviewContainer extends StatelessWidget {

--- a/lib/src/widgets/side_bar_panel.dart
+++ b/lib/src/widgets/side_bar_panel.dart
@@ -1,3 +1,4 @@
+import 'package:dashbook/src/device_size_extension.dart';
 import 'package:dashbook/src/widgets/icon.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -24,6 +25,8 @@ class SideBarPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final showTitleIcon = context.isNotPhoneSize;
+
     return Container(
       color: Theme.of(context).cardColor,
       width: width,
@@ -53,7 +56,7 @@ class SideBarPanel extends StatelessWidget {
                               left: 8,
                             ),
                             child: Opacity(
-                              opacity: kIsWeb ? 1 : 0,
+                              opacity: showTitleIcon ? 1 : 0,
                               child: titleIcon,
                             ),
                           ),

--- a/lib/src/widgets/side_bar_panel.dart
+++ b/lib/src/widgets/side_bar_panel.dart
@@ -1,6 +1,5 @@
 import 'package:dashbook/src/device_size_extension.dart';
 import 'package:dashbook/src/widgets/icon.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class SideBarPanel extends StatelessWidget {

--- a/lib/src/widgets/widget.dart
+++ b/lib/src/widgets/widget.dart
@@ -1,4 +1,5 @@
 import 'package:dashbook/dashbook.dart';
+import 'package:dashbook/src/device_size_extension.dart';
 import 'package:dashbook/src/platform_utils/platform_utils.dart';
 import 'package:dashbook/src/preferences.dart';
 import 'package:dashbook/src/story_util.dart';
@@ -251,7 +252,8 @@ class _DashbookState extends State<Dashbook> {
                       child: Stack(
                         children: [
                           if (_currentChapter != null &&
-                              (kIsWeb || _currentView != CurrentView.stories))
+                              (context.isNotPhoneSize ||
+                                  _currentView != CurrentView.stories))
                             PreviewContainer(
                               key: Key(_currentChapter!.id),
                               usePreviewSafeArea: widget.usePreviewSafeArea,


### PR DESCRIPTION
Currently there is quite a bit of logic related to kIsWeb, for example the story navigation widget and the chapter itself are never shown side-by-side on desktop. On the other hand it does show large-screen features on mobile web.

This PR adds screen size logic to the library and applies it where it makes sense. The only kIsWeb that still makes sense is that for sharing an url, but even that could be useful on non-web applications. (But current implementation would be broken.)