### PR TITLE
Add option to auto pin stories on large screens

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ void main() {
     light: ThemeData(),
     dark: ThemeData.dark(),
     title: 'Dashbook Example',
+    autoPinStoriesOnLargeScreen: true,
   );
 
   addTextStories(dashbook);

--- a/example/lib/main_without_theme.dart
+++ b/example/lib/main_without_theme.dart
@@ -4,7 +4,7 @@ import 'package:example/text_story.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  final dashbook = Dashbook();
+  final dashbook = Dashbook(autoPinStoriesOnLargeScreen: true);
 
   addTextStories(dashbook);
   addStories(dashbook);

--- a/lib/src/device_size_extension.dart
+++ b/lib/src/device_size_extension.dart
@@ -15,6 +15,11 @@ extension DeviceSizeExtension on BuildContext {
   bool get isTabletSize => sizeCategory == SizeCategory.tablet;
   bool get isLaptopSize => sizeCategory == SizeCategory.laptop;
   bool get isDesktopSize => sizeCategory == SizeCategory.desktop;
+
+  bool get isWideScreen {
+    final width = MediaQuery.of(this).size.width;
+    return width > _Breakpoint.large;
+  }
 }
 
 enum SizeCategory {

--- a/lib/src/widgets/side_bar_panel.dart
+++ b/lib/src/widgets/side_bar_panel.dart
@@ -10,6 +10,7 @@ class SideBarPanel extends StatelessWidget {
   final Key? onCloseKey;
   final double width;
   final DashbookIcon? titleIcon;
+  final bool sideBarIsAlwaysShown;
 
   const SideBarPanel({
     Key? key,
@@ -20,11 +21,12 @@ class SideBarPanel extends StatelessWidget {
     this.onCloseKey,
     this.titleIcon,
     required this.width,
+    this.sideBarIsAlwaysShown = false,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final showTitleIcon = context.isNotPhoneSize;
+    final showTitleIcon = context.isNotPhoneSize && !sideBarIsAlwaysShown;
 
     return Container(
       color: Theme.of(context).cardColor,
@@ -68,16 +70,17 @@ class SideBarPanel extends StatelessWidget {
               ),
             ),
           ),
-          Positioned(
-            right: 15,
-            top: 15,
-            child: DashbookIcon(
-              key: onCloseKey,
-              tooltip: 'Close',
-              icon: Icons.clear,
-              onClick: () => onCancel?.call(),
+          if (!sideBarIsAlwaysShown)
+            Positioned(
+              right: 15,
+              top: 15,
+              child: DashbookIcon(
+                key: onCloseKey,
+                tooltip: 'Close',
+                icon: Icons.clear,
+                onClick: () => onCancel?.call(),
+              ),
             ),
-          ),
         ],
       ),
     );

--- a/lib/src/widgets/stories_list.dart
+++ b/lib/src/widgets/stories_list.dart
@@ -21,6 +21,7 @@ class StoriesList extends StatefulWidget {
   final String currentFilter;
   final bool storyPanelPinned;
   final void Function() onStoryPinChange;
+  final bool storiesAreAlwaysShown;
 
   const StoriesList({
     required this.stories,
@@ -33,6 +34,7 @@ class StoriesList extends StatefulWidget {
     required this.currentFilter,
     required this.storyPanelPinned,
     required this.onStoryPinChange,
+    required this.storiesAreAlwaysShown,
     Key? key,
     this.selectedChapter,
   }) : super(key: key);
@@ -114,6 +116,7 @@ class _StoriesListState extends State<StoriesList> {
         onCloseKey: kStoriesCloseIcon,
         scrollViewKey: const PageStorageKey<String>('stories_list'),
         onCancel: widget.onCancel,
+        sideBarIsAlwaysShown: widget.storiesAreAlwaysShown,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [

--- a/lib/src/widgets/widget.dart
+++ b/lib/src/widgets/widget.dart
@@ -49,6 +49,7 @@ class Dashbook extends StatefulWidget {
   final _DashbookMultiTheme? _multiTheme;
   final String title;
   final bool usePreviewSafeArea;
+  final bool autoPinStoriesOnLargeScreen;
   final GlobalKey<NavigatorState>? navigatorKey;
 
   /// Called whenever a new chapter is selected.
@@ -59,6 +60,7 @@ class Dashbook extends StatefulWidget {
     this.theme,
     this.title = '',
     this.usePreviewSafeArea = false,
+    this.autoPinStoriesOnLargeScreen = false,
     this.navigatorKey,
     this.onChapterChange,
   })  : _dualTheme = null,
@@ -72,6 +74,7 @@ class Dashbook extends StatefulWidget {
     bool initWithLight = true,
     this.title = '',
     this.usePreviewSafeArea = false,
+    this.autoPinStoriesOnLargeScreen = false,
     this.navigatorKey,
     this.onChapterChange,
   })  : _dualTheme = _DashbookDualTheme(
@@ -89,6 +92,7 @@ class Dashbook extends StatefulWidget {
     String? initialTheme,
     this.title = '',
     this.usePreviewSafeArea = false,
+    this.autoPinStoriesOnLargeScreen = false,
     this.navigatorKey,
     this.onChapterChange,
   })  : _multiTheme =
@@ -203,11 +207,15 @@ class _DashbookState extends State<Dashbook> {
         return MaterialPageRoute<void>(
           builder: (context) {
             final chapterWidget = _currentChapter?.widget();
+            final alwaysShowStories =
+                widget.autoPinStoriesOnLargeScreen && context.isWideScreen;
+
             return Scaffold(
               body: SafeArea(
                 child: Row(
                   children: [
-                    if (_currentView == CurrentView.stories)
+                    if (_currentView == CurrentView.stories ||
+                        alwaysShowStories)
                       Drawer(
                         child: StoriesList(
                           stories: widget.stories,
@@ -220,6 +228,7 @@ class _DashbookState extends State<Dashbook> {
                               _storyPanelPinned = !_storyPanelPinned;
                             });
                           },
+                          storiesAreAlwaysShown: alwaysShowStories,
                           onUpdateFilter: (value) {
                             _storiesFilter = value;
                           },
@@ -432,7 +441,8 @@ class _DashbookState extends State<Dashbook> {
                               ],
                             ),
                           ),
-                          if (_currentView != CurrentView.stories)
+                          if (_currentView != CurrentView.stories &&
+                              !alwaysShowStories)
                             Positioned(
                               top: 5,
                               left: 10,


### PR DESCRIPTION
This feature adds an option to auto-pin the stories bar. When it is enabled it removes the icons of 'pin' and 'navigator' as those don't have any impact. The status of pin and whether or not the sidebar was open on smaller size is kept and automatically applied when the screen is made smaller.

video: https://drive.google.com/file/d/16q5Bks75LhpcysdyRaTvYfiVruwHFxAy/view?usp=sharing
![image](https://user-images.githubusercontent.com/15101411/184387634-59ed596a-d648-4b5e-afd1-0165c0eb94f2.png)


