### PR TITLE
Multi brand implementation

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,15 +4,56 @@ import 'package:example/text_story.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  final dashbook = Dashbook.dualTheme(
-    light: ThemeData(),
-    dark: ThemeData.dark(),
-    title: 'Dashbook Example',
-    autoPinStoriesOnLargeScreen: true,
+  final dashbook = MultiBrandBookBuilder(
+    brands: [
+      DashbookBrand(
+        name: 'love',
+        themeSettings: getThemes(TestBrand.love),
+        icon: Icon(Icons.favorite),
+      ),
+      DashbookBrand(
+        name: 'hate',
+        themeSettings: getThemes(TestBrand.hate),
+        icon: Icon(Icons.heart_broken_outlined),
+      ),
+    ],
   );
 
   addTextStories(dashbook);
   addStories(dashbook);
 
-  runApp(dashbook);
+  runApp(dashbook.build());
+}
+
+enum TestBrand {
+  love,
+  hate,
+}
+
+ThemeSettings getThemes(TestBrand brand) {
+  switch (brand) {
+    case TestBrand.love:
+      final dualTheme = DashbookDualTheme(
+        light: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.red,
+            brightness: Brightness.light,
+          ),
+        ),
+        dark: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.red,
+            brightness: Brightness.dark,
+          ),
+        ),
+      );
+      return ThemeSettings(dualTheme: dualTheme);
+    case TestBrand.hate:
+      return ThemeSettings(
+        theme: ThemeData(
+          brightness: Brightness.light,
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.black),
+        ),
+      );
+  }
 }

--- a/example/lib/stories.dart
+++ b/example/lib/stories.dart
@@ -2,7 +2,7 @@ import 'package:dashbook/dashbook.dart';
 import 'package:example/widgets/message_card.dart';
 import 'package:flutter/material.dart';
 
-void addStories(Dashbook dashbook) {
+void addStories(MultiBrandBookBuilder dashbook) {
   dashbook.storiesOf('ElevatedButton').decorator(CenterDecorator()).add(
         'default',
         (ctx) => ElevatedButton(

--- a/example/lib/text_story.dart
+++ b/example/lib/text_story.dart
@@ -1,7 +1,7 @@
 import 'package:dashbook/dashbook.dart';
 import 'package:flutter/material.dart';
 
-void addTextStories(Dashbook dashbook) {
+void addTextStories(MultiBrandBookBuilder dashbook) {
   dashbook
       .storiesOf('Text')
       .decorator(CenterDecorator())

--- a/lib/dashbook.dart
+++ b/lib/dashbook.dart
@@ -1,3 +1,7 @@
+export './src/dashbook_config.dart';
 export './src/decorator.dart';
+export './src/multi_brand_dashbook/dashbook_brand.dart';
+export './src/multi_brand_dashbook/multi_brand_dashbook.dart';
 export './src/story.dart';
-export './src/widgets/widget.dart' show Dashbook, OnChapterChange;
+export './src/widgets/widget.dart'
+    show Dashbook, OnChapterChange, DashbookDualTheme, DashbookMultiTheme;

--- a/lib/src/dashbook_config.dart
+++ b/lib/src/dashbook_config.dart
@@ -1,0 +1,35 @@
+import 'package:dashbook/src/preferences.dart';
+import 'package:dashbook/src/story.dart';
+import 'package:dashbook/src/widgets/widget.dart';
+import 'package:flutter/material.dart';
+
+class DashbookConfig {
+  DashbookConfig({
+    required this.title,
+    required this.usePreviewSafeArea,
+    required this.autoPinStoriesOnLargeScreen,
+    required this.stories,
+    required this.preferences,
+  });
+
+  final String title;
+  final bool usePreviewSafeArea;
+  final bool autoPinStoriesOnLargeScreen;
+  final List<Story> stories;
+  final DashbookPreferences preferences;
+}
+
+class ThemeSettings {
+  ThemeSettings({
+    ThemeData? theme,
+    this.dualTheme,
+    this.multiTheme,
+  }) : currentTheme = theme ??
+            dualTheme?.light ??
+            multiTheme?.themes.values.first ??
+            ThemeData.light();
+
+  ThemeData currentTheme;
+  DashbookDualTheme? dualTheme;
+  DashbookMultiTheme? multiTheme;
+}

--- a/lib/src/multi_brand_dashbook/dashbook_brand.dart
+++ b/lib/src/multi_brand_dashbook/dashbook_brand.dart
@@ -1,0 +1,16 @@
+import 'package:dashbook/src/dashbook_config.dart';
+import 'package:flutter/widgets.dart';
+
+class DashbookBrand {
+  final String name;
+  final String path;
+  final Widget icon;
+  final ThemeSettings themeSettings;
+
+  const DashbookBrand({
+    required this.name,
+    String? path,
+    required this.icon,
+    required this.themeSettings,
+  }) : path = path ?? name;
+}

--- a/lib/src/multi_brand_dashbook/multi_brand_dashbook.dart
+++ b/lib/src/multi_brand_dashbook/multi_brand_dashbook.dart
@@ -129,7 +129,7 @@ class _MultiBrandDashbookState extends State<MultiBrandDashbook> {
         : SmallApp(
             brands: widget.brands,
             selectedIndex: widget.brands.indexOf(widget.selectedBrand),
-            onSelected: (i) => context.go('/${widget.brands[i].path}'),
+            onSelected: (i) => _navigate(brand: widget.brands[i].path),
             contentBuilder: builder,
           );
     return Theme(

--- a/lib/src/multi_brand_dashbook/multi_brand_dashbook.dart
+++ b/lib/src/multi_brand_dashbook/multi_brand_dashbook.dart
@@ -1,0 +1,197 @@
+import 'package:dashbook/dashbook.dart';
+import 'package:dashbook/src/dashbook_config.dart';
+import 'package:dashbook/src/multi_brand_dashbook/dashbook_brand.dart';
+import 'package:dashbook/src/multi_brand_dashbook/small_app.dart';
+import 'package:dashbook/src/multi_brand_dashbook/wide_app.dart';
+import 'package:dashbook/src/preferences.dart';
+import 'package:dashbook/src/widgets/dashbook_content.dart';
+import 'package:dashbook/src/widgets/widget.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+typedef OnSelectedIndexCallback = void Function(int index);
+typedef ContentBuilder = Widget Function(BuildContext context);
+
+class MultiBrandBookBuilder {
+  final List<Story> _stories = [];
+  final List<DashbookBrand> brands;
+
+  MultiBrandBookBuilder({required this.brands});
+
+  Story storiesOf(String name) {
+    final story = Story(name);
+    _stories.add(story);
+
+    return story;
+  }
+
+  Widget build() {
+    return MultiBrandApp(
+      brands: brands,
+      config: DashbookConfig(
+        usePreviewSafeArea: true,
+        autoPinStoriesOnLargeScreen: true,
+        preferences: DashbookPreferences(),
+        title: 'Dashbook',
+        stories: _stories,
+      ),
+    );
+  }
+}
+
+class MultiBrandApp extends StatelessWidget {
+  MultiBrandApp({
+    required this.brands,
+    required this.config,
+    Key? key,
+  }) : super(key: key);
+  final List<DashbookBrand> brands;
+  final DashbookConfig config;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      routeInformationProvider: _router.routeInformationProvider,
+      routeInformationParser: _router.routeInformationParser,
+      routerDelegate: _router.routerDelegate,
+      title: 'GoRouter Example',
+    );
+  }
+
+  late final GoRouter _router = _createRouter();
+
+  GoRouter _createRouter() {
+    final routes = brands
+        .map(
+          (e) => GoRoute(
+            path: '/${e.path}',
+            pageBuilder: (context, state) => CustomTransitionPage<void>(
+              key: state.pageKey,
+              child: MultiBrandDashbook(
+                brands: brands,
+                selectedBrand: e,
+                config: config,
+              ),
+              transitionsBuilder:
+                  (context, animation, secondaryAnimation, child) =>
+                      FadeTransition(opacity: animation, child: child),
+            ),
+          ),
+        )
+        .toList();
+
+    return GoRouter(
+      routes: routes,
+      redirect: (state) => state.path == '/' ? '/${brands.first.path}' : null,
+    );
+  }
+}
+
+class MultiBrandDashbook extends StatefulWidget {
+  const MultiBrandDashbook({
+    required this.brands,
+    required this.config,
+    required this.selectedBrand,
+    Key? key,
+  }) : super(key: key);
+  final List<DashbookBrand> brands;
+  final DashbookConfig config;
+  final DashbookBrand selectedBrand;
+
+  @override
+  State<MultiBrandDashbook> createState() => _MultiBrandDashbookState();
+}
+
+class _MultiBrandDashbookState extends State<MultiBrandDashbook> {
+  List<ThemeSettings> get themeSettings =>
+      widget.brands.map((e) => e.themeSettings).toList();
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+
+    final content = screenWidth > 500
+        ? WideApp(
+            brands: widget.brands,
+            selectedIndex: widget.brands.indexOf(widget.selectedBrand),
+            onSelected: (i) => context.go('/${widget.brands[i].path}'),
+            contentBuilder: builder,
+          )
+        : SmallApp(
+            brands: widget.brands,
+            selectedIndex: widget.brands.indexOf(widget.selectedBrand),
+            onSelected: (i) => context.go('/${widget.brands[i].path}'),
+            contentBuilder: builder,
+          );
+    return Theme(
+      data: widget.selectedBrand.themeSettings.currentTheme,
+      child: content,
+    );
+  }
+
+  Widget builder(BuildContext context) {
+    return _MultiBrandContent(
+      config: widget.config,
+      stories: widget.config.stories,
+      themeSettings: widget.selectedBrand.themeSettings,
+      onThemeChange: (themeData) {
+        setState(() {
+          widget.selectedBrand.themeSettings.currentTheme = themeData;
+        });
+      },
+    );
+  }
+}
+
+class _MultiBrandContent extends StatefulWidget {
+  const _MultiBrandContent({
+    Key? key,
+    required this.config,
+    required this.themeSettings,
+    required this.onThemeChange,
+    required this.stories,
+  }) : super(key: key);
+  final DashbookConfig config;
+  final ThemeSettings themeSettings;
+  final OnThemeChange onThemeChange;
+  final List<Story> stories;
+
+  @override
+  State<_MultiBrandContent> createState() => _MultiBrandContentState();
+}
+
+class _MultiBrandContentState extends State<_MultiBrandContent> {
+  CurrentView? currentView = CurrentView.stories;
+  Chapter? currentChapter;
+
+  @override
+  void initState() {
+    super.initState();
+    currentChapter = widget.stories.first.chapters.first;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DashbookContent(
+      currentView: currentView,
+      currentChapter: currentChapter,
+      config: widget.config,
+      onChapterChange: onChapterChange,
+      onViewChange: onViewChange,
+      themeSettings: widget.themeSettings,
+      onThemeChange: widget.onThemeChange,
+    );
+  }
+
+  void onChapterChange(Chapter chapter) {
+    setState(() {
+      currentChapter = chapter;
+    });
+  }
+
+  void onViewChange(CurrentView? view) {
+    setState(() {
+      currentView = view;
+    });
+  }
+}

--- a/lib/src/multi_brand_dashbook/small_app.dart
+++ b/lib/src/multi_brand_dashbook/small_app.dart
@@ -1,0 +1,61 @@
+import 'package:dashbook/src/multi_brand_dashbook/dashbook_brand.dart';
+import 'package:dashbook/src/multi_brand_dashbook/multi_brand_dashbook.dart';
+import 'package:flutter/material.dart';
+
+class SmallApp extends StatefulWidget {
+  const SmallApp({
+    required this.brands,
+    required this.selectedIndex,
+    required this.onSelected,
+    required this.contentBuilder,
+    Key? key,
+  }) : super(key: key);
+  final List<DashbookBrand> brands;
+  final int selectedIndex;
+  final OnSelectedIndexCallback onSelected;
+  final ContentBuilder contentBuilder;
+
+  @override
+  State<SmallApp> createState() => _SmallAppState();
+}
+
+class _SmallAppState extends State<SmallApp>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
+      vsync: this,
+      length: widget.brands.length,
+      initialIndex: widget.selectedIndex,
+    );
+    _tabController.addListener(() {
+      widget.onSelected(_tabController.index);
+    });
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+          Expanded(
+            child: widget.contentBuilder(context),
+          ),
+          TabBar(
+            controller: _tabController,
+            tabs: widget.brands.map((brand) => brand.icon).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/multi_brand_dashbook/wide_app.dart
+++ b/lib/src/multi_brand_dashbook/wide_app.dart
@@ -1,0 +1,49 @@
+import 'package:dashbook/src/multi_brand_dashbook/dashbook_brand.dart';
+import 'package:dashbook/src/multi_brand_dashbook/multi_brand_dashbook.dart';
+import 'package:flutter/material.dart';
+
+class WideApp extends StatelessWidget {
+  const WideApp({
+    required this.brands,
+    required this.selectedIndex,
+    required this.onSelected,
+    required this.contentBuilder,
+    Key? key,
+  }) : super(key: key);
+  final List<DashbookBrand> brands;
+  final int selectedIndex;
+  final OnSelectedIndexCallback onSelected;
+  final ContentBuilder contentBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Row(
+        children: <Widget>[
+          NavigationRail(
+            selectedIndex: selectedIndex,
+            onDestinationSelected: onSelected,
+            labelType: NavigationRailLabelType.none,
+            useIndicator: true,
+            indicatorColor: Colors.grey.shade300,
+            destinations: createDestinations(),
+          ),
+          const VerticalDivider(thickness: 1, width: 1),
+          // This is the main content.
+          Expanded(
+            child: contentBuilder(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<NavigationRailDestination> createDestinations() => brands
+      .map(
+        (brand) => NavigationRailDestination(
+          icon: brand.icon,
+          label: Text(brand.name),
+        ),
+      )
+      .toList();
+}

--- a/lib/src/widgets/dashbook_content.dart
+++ b/lib/src/widgets/dashbook_content.dart
@@ -1,0 +1,401 @@
+import 'package:dashbook/dashbook.dart';
+import 'package:dashbook/src/dashbook_config.dart';
+import 'package:dashbook/src/device_size_extension.dart';
+import 'package:dashbook/src/platform_utils/platform_utils.dart';
+import 'package:dashbook/src/preferences.dart';
+import 'package:dashbook/src/widgets/actions_container.dart';
+import 'package:dashbook/src/widgets/helpers.dart';
+import 'package:dashbook/src/widgets/icon.dart';
+import 'package:dashbook/src/widgets/intructions_dialog.dart';
+import 'package:dashbook/src/widgets/keys.dart';
+import 'package:dashbook/src/widgets/preview_container.dart';
+import 'package:dashbook/src/widgets/properties_container.dart';
+import 'package:dashbook/src/widgets/select_device/device_dialog.dart';
+import 'package:dashbook/src/widgets/stories_list.dart';
+import 'package:dashbook/src/widgets/widget.dart';
+import 'package:device_frame/device_frame.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart' as url_launcher;
+
+typedef OnChapterChange = void Function(Chapter);
+typedef OnViewChange = void Function(CurrentView?);
+typedef OnThemeChange = void Function(ThemeData);
+
+class DashbookContent extends StatefulWidget {
+  const DashbookContent({
+    Key? key,
+    required this.currentView,
+    required this.currentChapter,
+    required this.config,
+    required this.onChapterChange,
+    required this.onViewChange,
+    required this.themeSettings,
+    required this.onThemeChange,
+  }) : super(key: key);
+
+  final CurrentView? currentView;
+  final Chapter? currentChapter;
+  final DashbookConfig config;
+  final OnChapterChange onChapterChange;
+  final OnViewChange onViewChange;
+  final ThemeSettings themeSettings;
+  final OnThemeChange onThemeChange;
+
+  @override
+  State<DashbookContent> createState() => _DashbookContentState();
+}
+
+class _DashbookContentState extends State<DashbookContent> {
+  DashbookConfig get config => widget.config;
+  DashbookPreferences get _preferences => config.preferences;
+  Chapter? get _currentChapter => widget.currentChapter;
+  CurrentView? get _currentView => widget.currentView;
+
+  ThemeData get currentTheme => widget.themeSettings.currentTheme;
+  DashbookDualTheme? get dualTheme => widget.themeSettings.dualTheme;
+  DashbookMultiTheme? get multiTheme => widget.themeSettings.multiTheme;
+
+  bool _storyPanelPinned = false;
+  String _storiesFilter = '';
+
+  DeviceInfo? deviceInfo;
+  Orientation deviceOrientation = Orientation.portrait;
+  bool showDeviceFrame = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final chapterWidget = _currentChapter?.widget();
+    final alwaysShowStories =
+        config.autoPinStoriesOnLargeScreen && context.isWideScreen;
+
+    return SafeArea(
+      child: Row(
+        children: [
+          if (_currentView == CurrentView.stories || alwaysShowStories)
+            Drawer(
+              child: StoriesList(
+                stories: config.stories,
+                storyPanelPinned: _storyPanelPinned,
+                selectedChapter: _currentChapter,
+                currentBookmark: _preferences.bookmarkedChapter,
+                currentFilter: _storiesFilter,
+                onStoryPinChange: () {
+                  setState(() {
+                    _storyPanelPinned = !_storyPanelPinned;
+                  });
+                },
+                storiesAreAlwaysShown: alwaysShowStories,
+                onUpdateFilter: (value) {
+                  _storiesFilter = value;
+                },
+                onBookmarkChapter: (String bookmark) {
+                  setState(() {
+                    _preferences.bookmarkedChapter = bookmark;
+                  });
+                },
+                onClearBookmark: () {
+                  setState(() {
+                    _preferences.bookmarkedChapter = null;
+                  });
+                },
+                onCancel: () {
+                  widget.onViewChange(null);
+                  setState(() {
+                    _storyPanelPinned = false;
+                  });
+                },
+                onSelectChapter: (chapter) {
+                  widget.onChapterChange(chapter);
+                  if (!_storyPanelPinned) {
+                    widget.onViewChange(null);
+                  }
+                },
+              ),
+            ),
+          Expanded(
+            child: Stack(
+              children: [
+                if (_currentChapter != null &&
+                    (context.isNotPhoneSize ||
+                        _currentView != CurrentView.stories))
+                  PreviewContainer(
+                    key: Key(_currentChapter!.id),
+                    usePreviewSafeArea: config.usePreviewSafeArea,
+                    isPropertiesOpen: _currentView == CurrentView.properties ||
+                        _currentView == CurrentView.actions,
+                    deviceInfo: deviceInfo,
+                    deviceOrientation: deviceOrientation,
+                    showDeviceFrame: showDeviceFrame,
+                    info: _currentChapter?.pinInfo == true
+                        ? _currentChapter?.info
+                        : null,
+                    child: chapterWidget!,
+                  ),
+                Positioned(
+                  right: 10,
+                  top: 0,
+                  bottom: 0,
+                  child: _DashbookRightIconList(
+                    children: [
+                      if (_hasProperties())
+                        DashbookIcon(
+                          key: kPropertiesIcon,
+                          tooltip: 'Properties panel',
+                          icon: Icons.mode_edit,
+                          onClick: () {
+                            widget.onViewChange(CurrentView.properties);
+                            setState(() => _storyPanelPinned = false);
+                          },
+                        ),
+                      if (_hasActions())
+                        DashbookIcon(
+                          key: kActionsIcon,
+                          tooltip: 'Actions panel',
+                          icon: Icons.play_arrow,
+                          onClick: () {
+                            widget.onViewChange(CurrentView.actions);
+                            setState(() => _storyPanelPinned = false);
+                          },
+                        ),
+                      if (_currentChapter?.info != null &&
+                          _currentChapter?.pinInfo == false)
+                        DashbookIcon(
+                          tooltip: 'Instructions',
+                          icon: Icons.info,
+                          onClick: () {
+                            showDialog<void>(
+                              context: context,
+                              builder: (_) {
+                                return InstructionsDialog(
+                                  instructions: _currentChapter!.info!,
+                                );
+                              },
+                            );
+                          },
+                        ),
+                      if (_currentChapter?.codeLink != null)
+                        DashbookIcon(
+                          tooltip: 'See code',
+                          icon: Icons.code,
+                          onClick: () => _launchURL(_currentChapter!.codeLink!),
+                        ),
+                      if (dualTheme != null)
+                        _DashbookDualThemeIcon(
+                          dualTheme: dualTheme!,
+                          currentTheme: currentTheme,
+                          onChangeTheme: widget.onThemeChange,
+                        ),
+                      if (multiTheme != null)
+                        DashbookIcon(
+                          tooltip: 'Choose theme',
+                          icon: Icons.palette,
+                          onClick: () {
+                            showDialog<void>(
+                              context: context,
+                              useRootNavigator: false,
+                              builder: (_) => AlertDialog(
+                                title: const Text('Theme chooser'),
+                                content: DropdownButton<ThemeData>(
+                                  value: currentTheme,
+                                  items: multiTheme!.themes.entries
+                                      .map(
+                                        (entry) => DropdownMenuItem(
+                                          value: entry.value,
+                                          child: Text(entry.key),
+                                        ),
+                                      )
+                                      .toList(),
+                                  onChanged: (value) {
+                                    if (value != null) {
+                                      widget.onThemeChange(value);
+                                    }
+                                    Navigator.of(context).pop();
+                                  },
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      if (kIsWeb && _currentChapter != null)
+                        DashbookIcon(
+                          tooltip: 'Share this example',
+                          icon: Icons.share,
+                          onClick: () {
+                            final url = PlatformUtils.getChapterUrl(
+                              _currentChapter!,
+                            );
+                            Clipboard.setData(
+                              ClipboardData(text: url),
+                            );
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text(
+                                  'Link copied to your clipboard',
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      DashbookIcon(
+                        key: kDevicePreviewIcon,
+                        tooltip: 'Device preview',
+                        icon: Icons.phone_android_outlined,
+                        onClick: () async {
+                          final selectedDevice = await showDialog<DeviceInfo>(
+                            context: context,
+                            builder: (_) => DeviceDialog(
+                              currentSelection: deviceInfo,
+                            ),
+                          );
+
+                          setState(() => deviceInfo = selectedDevice);
+
+                          if (deviceInfo == null) {
+                            setState(() {
+                              deviceOrientation = Orientation.portrait;
+                            });
+                            setState(() => showDeviceFrame = true);
+                          }
+                        },
+                      ),
+                      if (deviceInfo != null)
+                        DashbookIcon(
+                          key: kRotateIcon,
+                          tooltip: 'Orientation',
+                          icon: Icons.screen_rotation_outlined,
+                          onClick: () => setState(() {
+                            deviceOrientation =
+                                deviceOrientation == Orientation.portrait
+                                    ? Orientation.landscape
+                                    : Orientation.portrait;
+                          }),
+                        ),
+                      if (deviceInfo != null)
+                        DashbookIcon(
+                          key: kHideFrameIcon,
+                          tooltip: 'Device frame',
+                          icon: Icons.mobile_off_outlined,
+                          onClick: () => setState(
+                            () => showDeviceFrame = !showDeviceFrame,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                if (_currentView != CurrentView.stories && !alwaysShowStories)
+                  Positioned(
+                    top: 5,
+                    left: 10,
+                    child: DashbookIcon(
+                      key: kStoriesIcon,
+                      tooltip: 'Navigator',
+                      icon: Icons.menu,
+                      onClick: () => setState(
+                        () => widget.onViewChange(CurrentView.stories),
+                      ),
+                    ),
+                  ),
+                if (_currentView == CurrentView.properties &&
+                    _currentChapter != null)
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    bottom: 0,
+                    child: PropertiesContainer(
+                      currentChapter: _currentChapter!,
+                      onCancel: () => widget.onViewChange(null),
+                      onPropertyChange: () {
+                        setState(() {});
+                      },
+                    ),
+                  ),
+                if (_currentView == CurrentView.actions &&
+                    _currentChapter != null)
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    bottom: 0,
+                    child: ActionsContainer(
+                      currentChapter: _currentChapter!,
+                      onCancel: () => widget.onViewChange(null),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _hasProperties() => _currentChapter?.ctx.properties.isNotEmpty ?? false;
+  bool _hasActions() => _currentChapter?.ctx.actions.isNotEmpty ?? false;
+
+  Future<void> _launchURL(String url) async {
+    final uri = Uri.parse(url);
+    if (await url_launcher.canLaunchUrl(uri)) {
+      await url_launcher.launchUrl(uri);
+    } else {
+      throw 'Could not launch $url';
+    }
+  }
+}
+
+class _DashbookRightIconList extends StatelessWidget {
+  final List<Widget> children;
+
+  const _DashbookRightIconList({
+    required this.children,
+  });
+
+  double _rightIconTop(int index, BuildContext ctx) =>
+      10.0 + index * iconSize(ctx);
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: iconSize(context),
+      child: Stack(
+        children: [
+          for (int index = 0; index < children.length; index++)
+            Positioned(
+              top: _rightIconTop(index, context),
+              child: children[index],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DashbookDualThemeIcon extends StatelessWidget {
+  final DashbookDualTheme dualTheme;
+  final ThemeData currentTheme;
+  final OnThemeChange onChangeTheme;
+
+  const _DashbookDualThemeIcon({
+    required this.dualTheme,
+    required this.currentTheme,
+    required this.onChangeTheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDarkThemeSelected = dualTheme.dark == currentTheme;
+    return DashbookIcon(
+      tooltip: isDarkThemeSelected
+          ? 'Change to light theme'
+          : 'Change to dark theme',
+      icon: isDarkThemeSelected ? Icons.nightlight_round : Icons.wb_sunny,
+      onClick: () {
+        if (isDarkThemeSelected) {
+          onChangeTheme(dualTheme.light);
+        } else {
+          onChangeTheme(dualTheme.dark);
+        }
+      },
+    );
+  }
+}

--- a/lib/src/widgets/dashbook_content.dart
+++ b/lib/src/widgets/dashbook_content.dart
@@ -19,7 +19,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
-typedef OnChapterChange = void Function(Chapter);
 typedef OnViewChange = void Function(CurrentView?);
 typedef OnThemeChange = void Function(ThemeData);
 

--- a/lib/src/widgets/widget.dart
+++ b/lib/src/widgets/widget.dart
@@ -1,42 +1,30 @@
 import 'package:dashbook/dashbook.dart';
-import 'package:dashbook/src/device_size_extension.dart';
+import 'package:dashbook/src/dashbook_config.dart';
 import 'package:dashbook/src/platform_utils/platform_utils.dart';
 import 'package:dashbook/src/preferences.dart';
 import 'package:dashbook/src/story_util.dart';
-import 'package:dashbook/src/widgets/actions_container.dart';
-import 'package:dashbook/src/widgets/helpers.dart';
-import 'package:dashbook/src/widgets/icon.dart';
-import 'package:dashbook/src/widgets/intructions_dialog.dart';
-import 'package:dashbook/src/widgets/keys.dart';
-import 'package:dashbook/src/widgets/preview_container.dart';
-import 'package:dashbook/src/widgets/properties_container.dart';
-import 'package:dashbook/src/widgets/select_device/device_dialog.dart';
-import 'package:dashbook/src/widgets/stories_list.dart';
-import 'package:device_frame/device_frame.dart';
-import 'package:flutter/foundation.dart';
+import 'package:dashbook/src/widgets/dashbook_content.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
 typedef OnChapterChange = void Function(Chapter);
 
-class _DashbookDualTheme {
+class DashbookDualTheme {
   final ThemeData light;
   final ThemeData dark;
   final bool initWithLight;
 
-  _DashbookDualTheme({
+  DashbookDualTheme({
     required this.light,
     required this.dark,
     this.initWithLight = true,
   });
 }
 
-class _DashbookMultiTheme {
+class DashbookMultiTheme {
   final Map<String, ThemeData> themes;
   final String? initialTheme;
 
-  _DashbookMultiTheme({
+  DashbookMultiTheme({
     required this.themes,
     this.initialTheme,
   });
@@ -45,8 +33,8 @@ class _DashbookMultiTheme {
 class Dashbook extends StatefulWidget {
   final List<Story> stories = [];
   final ThemeData? theme;
-  final _DashbookDualTheme? _dualTheme;
-  final _DashbookMultiTheme? _multiTheme;
+  final DashbookDualTheme? _dualTheme;
+  final DashbookMultiTheme? _multiTheme;
   final String title;
   final bool usePreviewSafeArea;
   final bool autoPinStoriesOnLargeScreen;
@@ -77,7 +65,7 @@ class Dashbook extends StatefulWidget {
     this.autoPinStoriesOnLargeScreen = false,
     this.navigatorKey,
     this.onChapterChange,
-  })  : _dualTheme = _DashbookDualTheme(
+  })  : _dualTheme = DashbookDualTheme(
           dark: dark,
           light: light,
           initWithLight: initWithLight,
@@ -96,7 +84,7 @@ class Dashbook extends StatefulWidget {
     this.navigatorKey,
     this.onChapterChange,
   })  : _multiTheme =
-            _DashbookMultiTheme(themes: themes, initialTheme: initialTheme),
+            DashbookMultiTheme(themes: themes, initialTheme: initialTheme),
         theme = null,
         _dualTheme = null,
         super(key: key);
@@ -126,11 +114,7 @@ class _DashbookState extends State<Dashbook> {
   ThemeData? _currentTheme;
   late DashbookPreferences _preferences;
   bool _loading = true;
-  String _storiesFilter = '';
-  DeviceInfo? deviceInfo;
-  Orientation deviceOrientation = Orientation.portrait;
-  bool showDeviceFrame = true;
-  bool _storyPanelPinned = false;
+  late DashbookConfig dashbookConfig;
 
   @override
   void initState() {
@@ -176,20 +160,16 @@ class _DashbookState extends State<Dashbook> {
     setState(() {
       _currentChapter = initialChapter;
       _preferences = preferences;
+
+      dashbookConfig = DashbookConfig(
+        title: widget.title,
+        usePreviewSafeArea: widget.usePreviewSafeArea,
+        autoPinStoriesOnLargeScreen: widget.autoPinStoriesOnLargeScreen,
+        stories: widget.stories,
+        preferences: _preferences,
+      );
       _loading = false;
     });
-  }
-
-  bool _hasProperties() => _currentChapter?.ctx.properties.isNotEmpty ?? false;
-  bool _hasActions() => _currentChapter?.ctx.actions.isNotEmpty ?? false;
-
-  Future<void> _launchURL(String url) async {
-    final uri = Uri.parse(url);
-    if (await url_launcher.canLaunchUrl(uri)) {
-      await url_launcher.launchUrl(uri);
-    } else {
-      throw 'Could not launch $url';
-    }
   }
 
   @override
@@ -206,348 +186,27 @@ class _DashbookState extends State<Dashbook> {
       onGenerateRoute: (settings) {
         return MaterialPageRoute<void>(
           builder: (context) {
-            final chapterWidget = _currentChapter?.widget();
-            final alwaysShowStories =
-                widget.autoPinStoriesOnLargeScreen && context.isWideScreen;
-
             return Scaffold(
-              body: SafeArea(
-                child: Row(
-                  children: [
-                    if (_currentView == CurrentView.stories ||
-                        alwaysShowStories)
-                      Drawer(
-                        child: StoriesList(
-                          stories: widget.stories,
-                          storyPanelPinned: _storyPanelPinned,
-                          selectedChapter: _currentChapter,
-                          currentBookmark: _preferences.bookmarkedChapter,
-                          currentFilter: _storiesFilter,
-                          onStoryPinChange: () {
-                            setState(() {
-                              _storyPanelPinned = !_storyPanelPinned;
-                            });
-                          },
-                          storiesAreAlwaysShown: alwaysShowStories,
-                          onUpdateFilter: (value) {
-                            _storiesFilter = value;
-                          },
-                          onBookmarkChapter: (String bookmark) {
-                            setState(() {
-                              _preferences.bookmarkedChapter = bookmark;
-                            });
-                          },
-                          onClearBookmark: () {
-                            setState(() {
-                              _preferences.bookmarkedChapter = null;
-                            });
-                          },
-                          onCancel: () => setState(() {
-                            _currentView = null;
-                            _storyPanelPinned = false;
-                          }),
-                          onSelectChapter: (chapter) {
-                            widget.onChapterChange?.call(chapter);
-                            setState(() {
-                              _currentChapter = chapter;
-                              if (!_storyPanelPinned) {
-                                _currentView = null;
-                              }
-                            });
-                          },
-                        ),
-                      ),
-                    Expanded(
-                      child: Stack(
-                        children: [
-                          if (_currentChapter != null &&
-                              (context.isNotPhoneSize ||
-                                  _currentView != CurrentView.stories))
-                            PreviewContainer(
-                              key: Key(_currentChapter!.id),
-                              usePreviewSafeArea: widget.usePreviewSafeArea,
-                              isPropertiesOpen:
-                                  _currentView == CurrentView.properties ||
-                                      _currentView == CurrentView.actions,
-                              deviceInfo: deviceInfo,
-                              deviceOrientation: deviceOrientation,
-                              showDeviceFrame: showDeviceFrame,
-                              info: _currentChapter?.pinInfo == true
-                                  ? _currentChapter?.info
-                                  : null,
-                              child: chapterWidget!,
-                            ),
-                          Positioned(
-                            right: 10,
-                            top: 0,
-                            bottom: 0,
-                            child: _DashbookRightIconList(
-                              children: [
-                                if (_hasProperties())
-                                  DashbookIcon(
-                                    key: kPropertiesIcon,
-                                    tooltip: 'Properties panel',
-                                    icon: Icons.mode_edit,
-                                    onClick: () => setState(
-                                      () {
-                                        _currentView = CurrentView.properties;
-                                        _storyPanelPinned = false;
-                                      },
-                                    ),
-                                  ),
-                                if (_hasActions())
-                                  DashbookIcon(
-                                    key: kActionsIcon,
-                                    tooltip: 'Actions panel',
-                                    icon: Icons.play_arrow,
-                                    onClick: () => setState(
-                                      () {
-                                        _currentView = CurrentView.actions;
-                                        _storyPanelPinned = false;
-                                      },
-                                    ),
-                                  ),
-                                if (_currentChapter?.info != null &&
-                                    _currentChapter?.pinInfo == false)
-                                  DashbookIcon(
-                                    tooltip: 'Instructions',
-                                    icon: Icons.info,
-                                    onClick: () {
-                                      showDialog<void>(
-                                        context: context,
-                                        builder: (_) {
-                                          return InstructionsDialog(
-                                            instructions:
-                                                _currentChapter!.info!,
-                                          );
-                                        },
-                                      );
-                                    },
-                                  ),
-                                if (_currentChapter?.codeLink != null)
-                                  DashbookIcon(
-                                    tooltip: 'See code',
-                                    icon: Icons.code,
-                                    onClick: () =>
-                                        _launchURL(_currentChapter!.codeLink!),
-                                  ),
-                                if (widget._dualTheme != null)
-                                  _DashbookDualThemeIcon(
-                                    dualTheme: widget._dualTheme!,
-                                    currentTheme: _currentTheme!,
-                                    onChangeTheme: (theme) =>
-                                        setState(() => _currentTheme = theme),
-                                  ),
-                                if (widget._multiTheme != null)
-                                  DashbookIcon(
-                                    tooltip: 'Choose theme',
-                                    icon: Icons.palette,
-                                    onClick: () {
-                                      showDialog<void>(
-                                        context: context,
-                                        useRootNavigator: false,
-                                        builder: (_) => AlertDialog(
-                                          title: const Text('Theme chooser'),
-                                          content: DropdownButton<ThemeData>(
-                                            value: _currentTheme,
-                                            items: widget
-                                                ._multiTheme!.themes.entries
-                                                .map(
-                                                  (entry) => DropdownMenuItem(
-                                                    value: entry.value,
-                                                    child: Text(entry.key),
-                                                  ),
-                                                )
-                                                .toList(),
-                                            onChanged: (value) {
-                                              if (value != null) {
-                                                setState(
-                                                  () => _currentTheme = value,
-                                                );
-                                              }
-                                              Navigator.of(context).pop();
-                                            },
-                                          ),
-                                        ),
-                                      );
-                                    },
-                                  ),
-                                if (kIsWeb && _currentChapter != null)
-                                  DashbookIcon(
-                                    tooltip: 'Share this example',
-                                    icon: Icons.share,
-                                    onClick: () {
-                                      final url = PlatformUtils.getChapterUrl(
-                                        _currentChapter!,
-                                      );
-                                      Clipboard.setData(
-                                        ClipboardData(text: url),
-                                      );
-                                      ScaffoldMessenger.of(context)
-                                          .showSnackBar(
-                                        const SnackBar(
-                                          content: Text(
-                                            'Link copied to your clipboard',
-                                          ),
-                                        ),
-                                      );
-                                    },
-                                  ),
-                                DashbookIcon(
-                                  key: kDevicePreviewIcon,
-                                  tooltip: 'Device preview',
-                                  icon: Icons.phone_android_outlined,
-                                  onClick: () async {
-                                    final selectedDevice =
-                                        await showDialog<DeviceInfo>(
-                                      context: context,
-                                      builder: (_) => DeviceDialog(
-                                        currentSelection: deviceInfo,
-                                      ),
-                                    );
-
-                                    setState(() => deviceInfo = selectedDevice);
-
-                                    if (deviceInfo == null) {
-                                      setState(() {
-                                        deviceOrientation =
-                                            Orientation.portrait;
-                                      });
-                                      setState(() => showDeviceFrame = true);
-                                    }
-                                  },
-                                ),
-                                if (deviceInfo != null)
-                                  DashbookIcon(
-                                    key: kRotateIcon,
-                                    tooltip: 'Orientation',
-                                    icon: Icons.screen_rotation_outlined,
-                                    onClick: () => setState(() {
-                                      deviceOrientation = deviceOrientation ==
-                                              Orientation.portrait
-                                          ? Orientation.landscape
-                                          : Orientation.portrait;
-                                    }),
-                                  ),
-                                if (deviceInfo != null)
-                                  DashbookIcon(
-                                    key: kHideFrameIcon,
-                                    tooltip: 'Device frame',
-                                    icon: Icons.mobile_off_outlined,
-                                    onClick: () => setState(
-                                      () => showDeviceFrame = !showDeviceFrame,
-                                    ),
-                                  ),
-                              ],
-                            ),
-                          ),
-                          if (_currentView != CurrentView.stories &&
-                              !alwaysShowStories)
-                            Positioned(
-                              top: 5,
-                              left: 10,
-                              child: DashbookIcon(
-                                key: kStoriesIcon,
-                                tooltip: 'Navigator',
-                                icon: Icons.menu,
-                                onClick: () => setState(
-                                  () => _currentView = CurrentView.stories,
-                                ),
-                              ),
-                            ),
-                          if (_currentView == CurrentView.properties &&
-                              _currentChapter != null)
-                            Positioned(
-                              top: 0,
-                              right: 0,
-                              bottom: 0,
-                              child: PropertiesContainer(
-                                currentChapter: _currentChapter!,
-                                onCancel: () =>
-                                    setState(() => _currentView = null),
-                                onPropertyChange: () {
-                                  setState(() {});
-                                },
-                              ),
-                            ),
-                          if (_currentView == CurrentView.actions &&
-                              _currentChapter != null)
-                            Positioned(
-                              top: 0,
-                              right: 0,
-                              bottom: 0,
-                              child: ActionsContainer(
-                                currentChapter: _currentChapter!,
-                                onCancel: () =>
-                                    setState(() => _currentView = null),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                  ],
+              body: DashbookContent(
+                config: dashbookConfig,
+                currentChapter: _currentChapter,
+                currentView: _currentView,
+                onChapterChange: (chapter) => setState(
+                  () => _currentChapter = chapter,
                 ),
+                onViewChange: (view) => setState(
+                  () => _currentView = view,
+                ),
+                themeSettings: ThemeSettings(
+                  theme: _currentTheme,
+                  dualTheme: widget._dualTheme,
+                  multiTheme: widget._multiTheme,
+                ),
+                onThemeChange: (theme) => setState(() => _currentTheme = theme),
               ),
             );
           },
         );
-      },
-    );
-  }
-}
-
-class _DashbookRightIconList extends StatelessWidget {
-  final List<Widget> children;
-
-  const _DashbookRightIconList({
-    required this.children,
-  });
-
-  double _rightIconTop(int index, BuildContext ctx) =>
-      10.0 + index * iconSize(ctx);
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: iconSize(context),
-      child: Stack(
-        children: [
-          for (int index = 0; index < children.length; index++)
-            Positioned(
-              top: _rightIconTop(index, context),
-              child: children[index],
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-class _DashbookDualThemeIcon extends StatelessWidget {
-  final _DashbookDualTheme dualTheme;
-  final ThemeData currentTheme;
-  final Function(ThemeData) onChangeTheme;
-
-  const _DashbookDualThemeIcon({
-    required this.dualTheme,
-    required this.currentTheme,
-    required this.onChangeTheme,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final isDarkthemeSelected = dualTheme.dark == currentTheme;
-    return DashbookIcon(
-      tooltip: isDarkthemeSelected
-          ? 'Change to light theme'
-          : 'Change to dark theme',
-      icon: isDarkthemeSelected ? Icons.nightlight_round : Icons.wb_sunny,
-      onClick: () {
-        if (isDarkthemeSelected) {
-          onChangeTheme(dualTheme.light);
-        } else {
-          onChangeTheme(dualTheme.dark);
-        }
       },
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   flutter_colorpicker: ^1.0.3
   flutter_markdown: ^0.6.9
+  go_router: ^4.4.1
   shared_preferences: ^2.0.13
   url_launcher: ^6.1.2
 


### PR DESCRIPTION
This PR is for discussion and inspiration.

I've done 2 main things, 
1. split the content from the MaterialApp
2. create a different multibrand app with custom navigation logic

**1. Split the content**
I've moved the dashbook content from widget.dart to dashbook_content.dart. Having everything in a MaterialApp makes it very easy to build a simple dashbook, but makes it harder to customize. For example it is not possible to supply other localization delegates. Having the DashbookContent separated gives developers an option to further customize the experience to their needs. I would say that this change is very useful and cleans up the code a bit.

**2. Create multibrand app (WIP)**
An example off the multibrand app can be found at: https://renefloor.github.io/dashbook
The multi brand app enables a dev to create 1 storybook but with different theming settings. When you switch a brand the current state of the book is kept, but you have now different theming options. When the brand has 2 or more theming options the latest state is stored.
In this example GoRouter is used for navigation, this enabled me to update the path in the browser. That means you can always easily navigate to a specific chapter. The url is build using {brand}/{story}/{chapter}. Even though a multibrand app might not be the core usecase of dashbook, I believe structuring navigation this way would also be an improvement for the normal dashbook. For example you can now easily go to https://renefloor.github.io/dashbook/#/hate/container/with%20padding

When you don't think step 2 should be part of this package, I would be willing to make a separate package after the changes of step 1 are published. 

Couple of things not working yet:
* share button
* bookmark
* clean example main.dart file
* other things?
