### PR TITLE
fix: Remove usages of deprecated fields and bump to Flutter stable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,26 +1,47 @@
 name: Dashbook
 
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
-  build:
+  # BEGIN LINTING STAGE
+  format:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+      - uses: bluefireteam/melos-action@main
+      - run: melos run format-check
 
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+      - uses: bluefireteam/melos-action@main
+      - run: melos run analyze
+  # END LINTING STAGE
+
+  # BEGIN TESTING STAGE
+  test:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1.5.3
+      - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '2.5.x'
+          channel: 'stable'
+          cache: true
+      - uses: bluefireteam/melos-action@main
+      - uses: bluefireteam/spec-action@main
+  # END TESTING STAGE
 
-
-      - name: Install Dependencies
-        run: flutter packages get
-
-      - name: Format
-        run: flutter format --set-exit-if-changed lib test
-
-      - name: Analyze
-        run: flutter analyze lib test
-
-      - name: Run tests
-        run: flutter test --no-pub --test-randomize-ordering-seed random

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,6 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-      - uses: bluefireteam/spec-action@main
+      - run: flutter test
   # END TESTING STAGE
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,7 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-      - uses: bluefireteam/melos-action@main
-      - run: melos run format-check
+      - run: flutter format --set-exit-if-changed lib test
 
   analyze:
     runs-on: ubuntu-latest
@@ -28,8 +27,7 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-      - uses: bluefireteam/melos-action@main
-      - run: melos run analyze
+      - run: flutter analyze lib test
   # END LINTING STAGE
 
   # BEGIN TESTING STAGE
@@ -41,7 +39,6 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-      - uses: bluefireteam/melos-action@main
       - uses: bluefireteam/spec-action@main
   # END TESTING STAGE
 

--- a/lib/src/widgets/property_widgets/color_property.dart
+++ b/lib/src/widgets/property_widgets/color_property.dart
@@ -63,7 +63,7 @@ class ColorPropertyState extends State<ColorProperty> {
       label: widget.property.name,
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
-          primary: currentColor,
+          backgroundColor: currentColor,
         ),
         onPressed: () async {
           await show();


### PR DESCRIPTION
Currently Flutter is pinned to an old version, this PR makes sure that we are always using the latest stable version of Flutter in the pipeline.