### PR TITLE
Add global `showDialog` method using non-root navigator

### DIFF
--- a/lib/src/widgets/helpers.dart
+++ b/lib/src/widgets/helpers.dart
@@ -16,3 +16,14 @@ double sideBarSizeProperties(BuildContext context) {
   final factor = isLargeScreen(context) ? 0.5 : 1;
   return screenWidth * factor;
 }
+
+Future<void> showPopup({
+  required BuildContext context,
+  required WidgetBuilder builder,
+}) async {
+  return showDialog<void>(
+    context: context,
+    builder: builder,
+    useRootNavigator: false,
+  );
+}

--- a/lib/src/widgets/property_widgets/border_radius_property.dart
+++ b/lib/src/widgets/property_widgets/border_radius_property.dart
@@ -90,7 +90,7 @@ class _BorderRadiusPropertyState extends State<BorderRadiusProperty> {
     }
   }
 
-  Future<void> show() => showDialog<void>(
+  Future<void> show() => showPopup(
         context: context,
         builder: (_) => FourIntegerForm(
           _confirmEdition,

--- a/lib/src/widgets/property_widgets/color_property.dart
+++ b/lib/src/widgets/property_widgets/color_property.dart
@@ -1,4 +1,5 @@
 import 'package:dashbook/dashbook.dart';
+import 'package:dashbook/src/widgets/helpers.dart';
 import 'package:dashbook/src/widgets/property_widgets/widgets/property_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
@@ -29,7 +30,7 @@ class ColorPropertyState extends State<ColorProperty> {
   }
 
   // raise the [showDialog] widget
-  Future<void> show() => showDialog<void>(
+  Future<void> show() => showPopup(
         context: context,
         builder: (_) => PropertyDialog(
           title: 'Pick a color!',

--- a/lib/src/widgets/property_widgets/edge_insets_property.dart
+++ b/lib/src/widgets/property_widgets/edge_insets_property.dart
@@ -83,7 +83,7 @@ class _EdgeInsetsPropertyState extends State<EdgeInsetsProperty> {
     }
   }
 
-  Future<void> show() => showDialog<void>(
+  Future<void> show() => showPopup(
         context: context,
         builder: (_) => FourIntegerForm(
           _confirmEdition,

--- a/lib/src/widgets/widget.dart
+++ b/lib/src/widgets/widget.dart
@@ -316,7 +316,7 @@ class _DashbookState extends State<Dashbook> {
                                       tooltip: 'Instructions',
                                       icon: Icons.info,
                                       onClick: () {
-                                        showDialog<void>(
+                                        showPopup(
                                           context: context,
                                           builder: (_) {
                                             return InstructionsDialog(
@@ -347,9 +347,8 @@ class _DashbookState extends State<Dashbook> {
                                       tooltip: 'Choose theme',
                                       icon: Icons.palette,
                                       onClick: () {
-                                        showDialog<void>(
+                                        showPopup(
                                           context: context,
-                                          useRootNavigator: false,
                                           builder: (_) => AlertDialog(
                                             title: const Text('Theme chooser'),
                                             content: DropdownButton<ThemeData>(


### PR DESCRIPTION
Resolves https://github.com/bluefireteam/dashbook/issues/84.

This issue seems to arise in scenarios involving nested navigators 
within the application. When displaying a dialog, setting `useRootNavigator: false` 
ensures that it is pushed to the current navigator rather than the root one.

To enhance clarity for contributors, I've introduced a global method for displaying dialogs. 
This serves as a clear reminder not to push dialogs to the root navigator.