### PR TITLE
fix: space in the shared url

### DIFF
--- a/lib/src/story.dart
+++ b/lib/src/story.dart
@@ -399,5 +399,5 @@ class Chapter {
     return story._decorator?.decorate(w) ?? w;
   }
 
-  String get id => '${story.name}_$name';
+  String get id => '${story.name}_$name'.replaceAll(' ', '_');
 }


### PR DESCRIPTION
Fixes #110

due to the id directly taking in the spaces from the names, the link shared is containing space in between '%20'. This commit replaces all the spaces with underscore character in the chapter id.

Just adding the `replaceAll` method to change ` ` (or `%20`) in links to `_` works good when both sharing and opening the link (as it is the identifier of that chapter).

PS: Tests are failing even before this commit.