### PR TITLE
refactor: make use of web instead of dart:html

### DIFF
--- a/lib/src/platform_utils/web.dart
+++ b/lib/src/platform_utils/web.dart
@@ -1,20 +1,18 @@
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html';
-
 import 'package:dashbook/dashbook.dart';
 import 'package:dashbook/src/story_util.dart';
+import 'package:web/web.dart' as web;
 
 class PlatformUtils {
   PlatformUtils._();
 
   static String getChapterUrl(Chapter chapter) {
     final plainUrl =
-        window.location.href.replaceFirst(window.location.hash, '');
+        web.window.location.href.replaceFirst(web.window.location.hash, '');
     return '$plainUrl#/${Uri.encodeComponent(chapter.id)}';
   }
 
   static Chapter? getInitialChapter(List<Story> stories) {
-    final hash = window.location.hash;
+    final hash = web.window.location.hash;
 
     if (hash.isNotEmpty) {
       final currentId = Uri.decodeComponent(hash.substring(2));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter_markdown: ^0.6.17+3
   shared_preferences: ^2.2.1
   url_launcher: ^6.1.14
+  web: ^0.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
with the new dart version, the dart:html will soon not be working in favour of the new [web](https://pub.dev/packages/web) package.

This commit changes to use the web package instead.

Web Migration Guide: https://dart.dev/interop/js-interop/package-web

Note: Tested in local with the latest Flutter 3.19 version and works fine 

PS: The 2 checks are failing even before this commit