### PR TITLE
fix: Bump colorpicker version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   device_frame: ^1.1.0
   flutter:
     sdk: flutter
-  flutter_colorpicker: ^1.0.3
+  flutter_colorpicker: ^1.1.0
   flutter_markdown: ^0.6.17+3
   shared_preferences: ^2.2.1
   url_launcher: ^6.1.14


### PR DESCRIPTION
Current version of colorpicker being resolved to 1.0.3 doesn't work anymore with any updated Flutter versions:

```
../../../../.pub-cache/hosted/pub.dev/flutter_colorpicker-1.0.3/lib/src/palette.dart:1045:47: Error: The getter
'bodyText2' isn't defined for the class 'TextTheme'.
 - 'TextTheme' is from 'package:flutter/src/material/text_theme.dart'
 ('../../../../softwares/flutter/packages/flutter/lib/src/material/text_theme.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'bodyText2'.
          width: (Theme.of(context).textTheme.bodyText2?.fontSize ?? 14) * 10,
```

This bumps the version to one that is definitely working. Tested with the example app.