### PR TITLE
Replaced the deprecated RaisedButton with the equivalent ElevatedButton.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ void main() {
       });
 
   dashbook
-      .storiesOf('RaisedButton')
+      .storiesOf('ElevatedButton')
       .decorator(CenterDecorator())
-      .add('default', (ctx) => RaisedButton(child: Text('Ok'), onPressed: () {}));
+      .add('default', (ctx) => ElevatedButton(child: Text('Ok'), onPressed: () {}));
 
   // Since dashbook is a widget itself, you can just call runApp passing it as a parameter
   runApp(dashbook);


### PR DESCRIPTION
Overall a pretty minor change to make the example work with the newest stable version of Flutter because of [the breaking changes](https://docs.flutter.dev/release/breaking-changes/buttons).

## Changes:
- Replaces `RaisedButton` with `ElevatedButton`.